### PR TITLE
Enochian pause polyglot fix

### DIFF
--- a/src/Game/GameState.ts
+++ b/src/Game/GameState.ts
@@ -637,6 +637,11 @@ export class GameState {
 			enochian.overrideTimer(this, 15);
 
 		} else {
+			// reset polyglot countdown to 30s if enochian wasn't actually active
+			if (!enochian.available(1)) {
+				this.resources.get(ResourceType.Polyglot).overrideTimer(this, 30);
+			}
+
 			// either fresh gain, or there's enochian but no timer
 			enochian.gain(1);
 
@@ -649,9 +654,6 @@ export class GameState {
 					this.loseEnochian();
 				}
 			});
-
-			// reset polyglot countdown to 30s
-			this.resources.get(ResourceType.Polyglot).overrideTimer(this, 30);
 		}
 	}
 

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -1,5 +1,11 @@
 [
 	{
+		"date": "8/9/24",
+		"changes": [
+			"Akairyu - Fix a bug with Polyglot timer handling when Enochian resumes after an Umbral Soul pause"
+		]
+	},
+	{
 		"date": "8/8/24",
 		"changes": [
 			"Added M2S markers and log CSV parsing script by shanzhe"


### PR DESCRIPTION
When the Enochian timer was paused due to using Umbral Soul, when that timer resumed, the Polyglot timer would get reset to the full 30s. In actual practice the timer just continues ticking as long as Enochian doesn't drop completely.

Moved and conditioned the simulated timer reset to match the way it behaves in-game.