### PR TITLE
Refactor default GameConfig and add consts for discord links

### DIFF
--- a/src/Components/IntroSection.tsx
+++ b/src/Components/IntroSection.tsx
@@ -5,6 +5,9 @@ import {DebugOptions} from "./DebugOptions";
 import changelog from "../changelog.json"
 import {getCurrentThemeColors} from "./ColorTheme";
 
+const HELP_CHANNEL_URL = "https://discordapp.com/channels/277897135515762698/1255782490862387360";
+const RESOURCE_CHANNEL_URL = "https://discordapp.com/channels/277897135515762698/1255595442926915584";
+
 function Changelog() {
 	return <div className={"paragraph"}><Expandable title={"Changelog"} titleNode={localize({en: "Changelog", zh: "更新日志", ja: "更新履歴"})} defaultShow={false} content={
 		<div>
@@ -179,7 +182,7 @@ export function IntroSection(props: {}) {
 				})}
 				{localize({
 					en: <div className={"paragraph"}>
-						If you have questions or would like to provide feedback, you can message in <a target={"_blank"} href={"https://discord.com/channels/277897135515762698/1255782490862387360"}>this thread in The Balance</a>.
+						If you have questions or would like to provide feedback, you can message in <a target={"_blank"} href={HELP_CHANNEL_URL}>this thread in The Balance</a>.
 						You can also find me directly on discord (miyehn), or via email (rainduym@gmail.com). In case of sending a bug report, attaching the
 						fight record (download "fight.txt" from the right or name it anything else) would be very helpful.
 					</div>,
@@ -208,7 +211,7 @@ export function IntroSection(props: {}) {
 						<li><a href={"https://spide-r.github.io/ffxiv-blm-rotation/"}>Black Mage in the Bozjan Shell</a>: a variation for Save the Queens areas, created by <b>A'zhek Silvaire @ Zalera</b></li>
 						<li><a href={"https://na.finalfantasyxiv.com/jobguide/blackmage/"}>Official FFXIV black mage job
 							guide</a></li>
-						<li><a target={"_blank"} href={"https://discordapp.com/channels/277897135515762698/1255595442926915584"}>
+						<li><a target={"_blank"} href={RESOURCE_CHANNEL_URL}>
 							BLM resources channel on The Balance</a> (make sure you've already joined the server)</li>
 					</ul>,
 					zh: <ul>
@@ -218,7 +221,7 @@ export function IntroSection(props: {}) {
 						<li><a href={"https://miyehn.me/ffxiv-blm-rotation-endwalker/"}>6.x版排轴器</a>，历史版本，几天后还会在那里展出一些6.0时期的轴，作为纪念。</li>
 						<li><a href={"https://spide-r.github.io/ffxiv-blm-rotation/"}>博兹雅版排轴器（Black Mage in the Bozjan Shell）</a>: 本工具的博兹雅/天佑女王版。制作者： <b>A'zhek Silvaire @ Zalera</b></li>
 						<li><a href={"https://na.finalfantasyxiv.com/jobguide/blackmage/"}>官方的黑魔法师职业介绍</a></li>
-						<li><a target={"_blank"} href={"https://discordapp.com/channels/277897135515762698/1255595442926915584"}>
+						<li><a target={"_blank"} href={RESOURCE_CHANNEL_URL}>
 							The Balance服务器里的黑魔频道</a> （需要先加入Discord服务器）</li>
 					</ul>,
 					ja:
@@ -226,7 +229,7 @@ export function IntroSection(props: {}) {
 						<li><a href={"https://github.com/miyehn/ffxiv-blm-rotation"}>Github repository</a></li>
 						<li><a href={"https://spide-r.github.io/ffxiv-blm-rotation/"}>Black Mage in the Bozjan Shell</a>: 南方ボズヤ戦線向けのツール。作者：<b>A'zhek Silvaire @ Zalera</b></li>
 						<li><a href={"https://na.finalfantasyxiv.com/jobguide/blackmage/"}>Official FFXIV black mage job guide</a></li>
-						<li><a target={"_blank"} href={"https://discordapp.com/channels/277897135515762698/1255595442926915584"}>
+						<li><a target={"_blank"} href={RESOURCE_CHANNEL_URL}>
 							BLM resources channel on The Balance</a> （ぜひDiscordサーバーに参加してください。） </li>
 					</ul>,
 				})}

--- a/src/Controller/Controller.ts
+++ b/src/Controller/Controller.ts
@@ -1,7 +1,7 @@
 import {getCachedValue, removeCachedValue, ReplayMode, setCachedValue, TickMode} from "./Common";
 import {GameState} from "../Game/GameState";
 import {Debug, ProcMode, ResourceType, SkillName, SkillReadyStatus, WarningType} from "../Game/Common";
-import {GameConfig} from "../Game/GameConfig"
+import {DEFAULT_CONFIG, GameConfig} from "../Game/GameConfig"
 // @ts-ignore
 import {updateStatusDisplay} from "../Components/StatusDisplay";
 // @ts-ignore
@@ -83,16 +83,6 @@ class Controller {
 		this.#presetLinesManager = new PresetLinesManager();
 
 		this.gameConfig = new GameConfig();
-		this.gameConfig.spellSpeed = 1532;
-		this.gameConfig.criticalHit = 420;
-		this.gameConfig.directHit = 420;
-		this.gameConfig.countdown = 5;
-		this.gameConfig.randomSeed = "sup";
-		this.gameConfig.casterTax = 0.1;
-		this.gameConfig.animationLock = 0.7;
-		this.gameConfig.timeTillFirstManaTick = 1.2;
-		this.gameConfig.procMode = ProcMode.Never;
-		this.gameConfig.extendedBuffTimes = false;
 		this.game = new GameState(this.gameConfig);
 
 		this.record = new Record();
@@ -691,17 +681,17 @@ class Controller {
 	}
 
 	setConfigAndRestart(props={
-		spellSpeed: 1268,
-		criticalHit: 420,
-		directHit: 420,
-		animationLock: 0.66,
-		casterTax: 0.06,
-		timeTillFirstManaTick: 0.3,
-		countdown: 5,
-		randomSeed: "hello.",
-		procMode: ProcMode.RNG,
-		extendedBuffTimes: false,
-		initialResourceOverrides: []
+		spellSpeed: DEFAULT_CONFIG.spellSpeed,
+		criticalHit: DEFAULT_CONFIG.criticalHit,
+		directHit: DEFAULT_CONFIG.directHit,
+		animationLock: DEFAULT_CONFIG.animationLock,
+		casterTax: DEFAULT_CONFIG.casterTax,
+		timeTillFirstManaTick: DEFAULT_CONFIG.timeTillFirstManaTick,
+		countdown: DEFAULT_CONFIG.countdown,
+		randomSeed: DEFAULT_CONFIG.randomSeed,
+		procMode: DEFAULT_CONFIG.procMode,
+		extendedBuffTimes: DEFAULT_CONFIG.extendedBuffTimes,
+		initialResourceOverrides: [],
 	}) {
 		this.gameConfig = new GameConfig(props);
 

--- a/src/Game/GameConfig.ts
+++ b/src/Game/GameConfig.ts
@@ -1,17 +1,31 @@
 import {Debug, SkillName, ProcMode} from "./Common";
 import {ResourceOverride} from "./Resources";
 
+export const DEFAULT_CONFIG = {
+	// 2.37 GCD
+	spellSpeed: 1532,
+	criticalHit: 420,
+	directHit: 420,
+	countdown: 5,
+	randomSeed: "sup",
+	casterTax: 0.1,
+	animationLock: 0.7,
+	timeTillFirstManaTick: 1.2,
+	procMode: ProcMode.Never,
+	extendedBuffTimes: false,
+};
+
 export class GameConfig {
-	spellSpeed = 400;
-	criticalHit = 420;
-	directHit = 420;
-	countdown = 0;
-	randomSeed = "hello.";
-	casterTax = 0.06;
-	animationLock = 0.66;
-	timeTillFirstManaTick = 1.2;
-	procMode = ProcMode.RNG;
-	extendedBuffTimes = false;
+	spellSpeed = DEFAULT_CONFIG.spellSpeed;
+	criticalHit = DEFAULT_CONFIG.criticalHit;
+	directHit = DEFAULT_CONFIG.directHit;
+	countdown = DEFAULT_CONFIG.countdown;
+	randomSeed = DEFAULT_CONFIG.randomSeed;
+	casterTax = DEFAULT_CONFIG.casterTax;
+	animationLock = DEFAULT_CONFIG.animationLock;
+	timeTillFirstManaTick = DEFAULT_CONFIG.timeTillFirstManaTick;
+	procMode = DEFAULT_CONFIG.procMode;
+	extendedBuffTimes = DEFAULT_CONFIG.extendedBuffTimes;
 	initialResourceOverrides: ResourceOverride[] = [];
 
 	// DEBUG
@@ -30,8 +44,8 @@ export class GameConfig {
 	}) {
 		if (props) {
 			this.spellSpeed = props.spellSpeed;
-			this.criticalHit = props.criticalHit ?? 420;
-			this.directHit = props.directHit ?? 420;
+			this.criticalHit = props.criticalHit ?? DEFAULT_CONFIG.criticalHit;
+			this.directHit = props.directHit ?? DEFAULT_CONFIG.directHit;
 			this.countdown = props.countdown;
 			this.randomSeed = props.randomSeed;
 			this.casterTax = props.casterTax;


### PR DESCRIPTION
It seems like the actual default values were previously being set in Controller's constructor despite appearing several places throughout the codebase; this refactor unifies everything and makes sure there's only one place to change the default config.

`initialResourceOverrides` is deliberately left out of `DEFAULT_CONFIG` because I'm concerned that `DEFAULT_CONFIG.initialResourceOverrides` would share the same mutable array object. I don't think this will cause issues, but it's worth keeping in mind.