### PR TITLE
Run eslint --fix

### DIFF
--- a/src/Components/ColorTheme.tsx
+++ b/src/Components/ColorTheme.tsx
@@ -193,11 +193,11 @@ export class SelectColorTheme extends React.Component {
 	}
 
 	componentDidMount() {
-		getCurrentColorTheme = (()=>{return this.state.colorTheme}).bind(this);
+		getCurrentColorTheme = (()=>{return this.state.colorTheme});
 		setCurrentColorTheme = ((colorTheme: ColorTheme)=>{
 			this.setState({colorTheme: colorTheme})
 			setCachedValue("colorTheme", colorTheme);
-		}).bind(this);
+		});
 	}
 	componentDidUpdate(prevProps: Readonly<{}>, prevState: Readonly<{colorTheme: ColorTheme}>, snapshot?: any) {
 		if (prevState.colorTheme !== this.state.colorTheme) {

--- a/src/Components/Common.tsx
+++ b/src/Components/Common.tsx
@@ -209,7 +209,7 @@ export class Input extends React.Component {
 		this.props = inProps;
 		this.onChange = ((e: ChangeEvent<{value: string}>)=>{
 			if (this.props.onChange) this.props.onChange(e.target.value);
-		}).bind(this);
+		});
 	}
 	render() {
 		let width = this.props.width ?? 5;
@@ -253,7 +253,7 @@ export class Slider extends React.Component {
 		this.onChange = ((e: ChangeEvent<{value: string}>)=>{
 			this.setState({value: e.target.value});
 			if (typeof this.props.onChange !== "undefined") this.props.onChange(e.target.value);
-		}).bind(this);
+		});
 	}
 	componentDidMount() {
 		if (typeof this.props.onChange !== "undefined") this.props.onChange(this.state.value);
@@ -317,7 +317,7 @@ export class Expandable extends React.Component {
 			if (this.props.onExpand && newShow) this.props.onExpand();
 			if (this.props.onCollapse && !newShow) this.props.onCollapse();
 			setCachedValue("exp: " + inProps.title, (newShow ? 1 : 0).toString());
-		}).bind(this);
+		});
 
 		let expanded = getCachedValue("exp: " + inProps.title);
 		let show: boolean = inProps.defaultShow ?? false;
@@ -366,7 +366,7 @@ export class LoadJsonFromFileOrUrl extends React.Component {
 
 		this.onLoadUrlChange = ((evt: ChangeEvent<{value: string}>)=>{
 			if (evt.target) this.loadUrl = evt.target.value;
-		}).bind(this);
+		});
 
 		this.onLoadPresetFile = (()=>{
 			let cur = this.fileSelectorRef.current;
@@ -377,7 +377,7 @@ export class LoadJsonFromFileOrUrl extends React.Component {
 				});
 				cur.value = "";
 			}
-		}).bind(this);
+		});
 
 		this.onLoadUrl = (()=>{
 			let errorHandler = function(e: any) {
@@ -393,7 +393,7 @@ export class LoadJsonFromFileOrUrl extends React.Component {
 			}, (e)=>{
 				errorHandler(e);
 			});
-		}).bind(this);
+		});
 	}
 	componentDidMount() {
 		if (this.props.loadUrlOnMount) this.onLoadUrl();

--- a/src/Components/DamageStatistics.tsx
+++ b/src/Components/DamageStatistics.tsx
@@ -218,11 +218,11 @@ export class DamageStatistics extends React.Component {
 		updateDamageStats = ((data: DamageStatisticsData) => {
 			this.data = data;
 			this.forceUpdate();
-		}).bind(this);
+		});
 		updateSelectedStats = ((selected: SelectedStatisticsData) => {
 			this.selected = selected;
 			this.forceUpdate();
-		}).bind(this);
+		});
 	}
 
 	componentWillUnmount() {

--- a/src/Components/IntroSection.tsx
+++ b/src/Components/IntroSection.tsx
@@ -179,7 +179,7 @@ export function IntroSection(props: {}) {
 				})}
 				{localize({
 					en: <div className={"paragraph"}>
-						If you have questions or would like to provide feedback, you can message in <a target={"_blank"} href={"https://discord.com/channels/277897135515762698/1255782490862387360"}>this thread in The Balance</a>.
+						If you have questions or would like to provide feedback, you can message in <a target={"_blank"} href={"https://discord.com/channels/277897135515762698/1255782490862387360"} rel="noreferrer">this thread in The Balance</a>.
 						You can also find me directly on discord (miyehn), or via email (rainduym@gmail.com). In case of sending a bug report, attaching the
 						fight record (download "fight.txt" from the right or name it anything else) would be very helpful.
 					</div>,
@@ -208,7 +208,7 @@ export function IntroSection(props: {}) {
 						<li><a href={"https://spide-r.github.io/ffxiv-blm-rotation/"}>Black Mage in the Bozjan Shell</a>: a variation for Save the Queens areas, created by <b>A'zhek Silvaire @ Zalera</b></li>
 						<li><a href={"https://na.finalfantasyxiv.com/jobguide/blackmage/"}>Official FFXIV black mage job
 							guide</a></li>
-						<li><a target={"_blank"} href={"https://discordapp.com/channels/277897135515762698/1255595442926915584"}>
+						<li><a target={"_blank"} href={"https://discordapp.com/channels/277897135515762698/1255595442926915584"} rel="noreferrer">
 							BLM resources channel on The Balance</a> (make sure you've already joined the server)</li>
 					</ul>,
 					zh: <ul>
@@ -218,7 +218,7 @@ export function IntroSection(props: {}) {
 						<li><a href={"https://miyehn.me/ffxiv-blm-rotation-endwalker/"}>6.x版排轴器</a>，历史版本，几天后还会在那里展出一些6.0时期的轴，作为纪念。</li>
 						<li><a href={"https://spide-r.github.io/ffxiv-blm-rotation/"}>博兹雅版排轴器（Black Mage in the Bozjan Shell）</a>: 本工具的博兹雅/天佑女王版。制作者： <b>A'zhek Silvaire @ Zalera</b></li>
 						<li><a href={"https://na.finalfantasyxiv.com/jobguide/blackmage/"}>官方的黑魔法师职业介绍</a></li>
-						<li><a target={"_blank"} href={"https://discordapp.com/channels/277897135515762698/1255595442926915584"}>
+						<li><a target={"_blank"} href={"https://discordapp.com/channels/277897135515762698/1255595442926915584"} rel="noreferrer">
 							The Balance服务器里的黑魔频道</a> （需要先加入Discord服务器）</li>
 					</ul>,
 					ja:
@@ -226,7 +226,7 @@ export function IntroSection(props: {}) {
 						<li><a href={"https://github.com/miyehn/ffxiv-blm-rotation"}>Github repository</a></li>
 						<li><a href={"https://spide-r.github.io/ffxiv-blm-rotation/"}>Black Mage in the Bozjan Shell</a>: 南方ボズヤ戦線向けのツール。作者：<b>A'zhek Silvaire @ Zalera</b></li>
 						<li><a href={"https://na.finalfantasyxiv.com/jobguide/blackmage/"}>Official FFXIV black mage job guide</a></li>
-						<li><a target={"_blank"} href={"https://discordapp.com/channels/277897135515762698/1255595442926915584"}>
+						<li><a target={"_blank"} href={"https://discordapp.com/channels/277897135515762698/1255595442926915584"} rel="noreferrer">
 							BLM resources channel on The Balance</a> （ぜひDiscordサーバーに参加してください。） </li>
 					</ul>,
 				})}

--- a/src/Components/LoadSave.tsx
+++ b/src/Components/LoadSave.tsx
@@ -28,7 +28,7 @@ export class LoadSave extends React.Component {
 				});
 				cur.value = "";
 			}
-		}).bind(this);
+		});
 
 		this.fileSelectorRef = React.createRef();
 	}

--- a/src/Components/Localization.tsx
+++ b/src/Components/Localization.tsx
@@ -191,11 +191,11 @@ export class SelectLanguage extends React.Component {
 	}
 
 	componentDidMount() {
-		getCurrentLanguage = (()=>{return this.state.lang}).bind(this);
+		getCurrentLanguage = (()=>{return this.state.lang});
 		setCurrentLanguage = ((lang: Language)=>{
 			this.setState({lang: lang})
 			setCachedValue("language", lang);
-		}).bind(this);
+		});
 	}
 	componentDidUpdate(prevProps: Readonly<{}>, prevState: Readonly<{lang: Language}>, snapshot?: any) {
 		if (prevState.lang !== this.state.lang) {

--- a/src/Components/Main.tsx
+++ b/src/Components/Main.tsx
@@ -14,7 +14,7 @@ import {SkillSequencePresets} from "./SkillSequencePresets";
 import {IntroSection} from "./IntroSection";
 import changelog from "../changelog.json"
 import {localize, localizeDate, SelectLanguage} from "./Localization"
-import {Expandable, GlobalHelpTooltip} from "./Common";
+import {GlobalHelpTooltip} from "./Common";
 import {getCurrentThemeColors, SelectColorTheme} from "./ColorTheme";
 import {DamageStatistics} from "./DamageStatistics";
 import {MAX_TIMELINE_SLOTS} from "../Controller/Timeline";
@@ -83,24 +83,24 @@ export default class Main extends React.Component {
 				controller.handleKeyboardEvent(evt);
 				evt.preventDefault();
 			}
-		}).bind(this);
+		});
 
 		this.gameplayMouseCapture = ((evt: React.MouseEvent)=>{
 			controller.displayCurrentState();
-		}).bind(this);
+		});
 
 		setRealTime = ((rt: boolean)=>{
 			this.setState({realTime: rt});
-		}).bind(this);
+		});
 
 		setHistorical = ((hi: boolean)=>{
 			this.setState({historical: hi});
-		}).bind(this);
+		});
 
 		forceUpdateAll = (()=>{
 			this.forceUpdate();
 			updateTimelineView();
-		}).bind(this);
+		});
 	}
 
 	componentDidMount() {

--- a/src/Components/PlaybackControl.js
+++ b/src/Components/PlaybackControl.js
@@ -42,7 +42,7 @@ export class TimeControl extends React.Component {
 					timeScale: this.state.timeScale
 				});
 			}
-		}).bind(this);
+		});
 
 		this.setTimeScale = ((val)=>{
 			this.setState({timeScale: val});
@@ -57,7 +57,7 @@ export class TimeControl extends React.Component {
 					timeScale: numVal
 				});
 			}
-		}).bind(this);
+		});
 
 		let settings = this.loadSettings();
 		if (settings) {
@@ -252,57 +252,57 @@ export class Config extends React.Component {
 				controller.scrollToTime();
 			}
 			event.preventDefault();
-		}).bind(this);
+		});
 
 		this.setSpellSpeed = (val => {
 			this.setState({spellSpeed: val, dirty: true});
-		}).bind(this);
+		});
 
 		this.setCriticalHit = (val => {
 			this.setState({criticalHit: val, dirty: true});
-		}).bind(this);
+		});
 
 		this.setDirectHit = (val => {
 			this.setState({directHit: val, dirty: true});
-		}).bind(this);
+		});
 
 		this.setAnimationLock = (val => {
 			this.setState({animationLock: val, dirty: true});
-		}).bind(this);
+		});
 
 		this.setCasterTax = (val => {
 			this.setState({casterTax: val, dirty: true});
-		}).bind(this);
+		});
 
 		this.setTimeTillFirstManaTick = (val => {
 			this.setState({timeTillFirstManaTick: val, dirty: true});
-		}).bind(this);
+		});
 
 		this.setCountdown = (val => {
 			this.setState({countdown: val, dirty: true});
-		}).bind(this);
+		});
 
 		this.setRandomSeed = (val => {
 			this.setState({randomSeed: val, dirty: true});
-		}).bind(this);
+		});
 
 		this.setExtendedBuffTimes = (evt => {
 			this.setState({extendedBuffTimes: evt.target.checked, dirty: true});
-		}).bind(this);
+		});
 
 		this.setProcMode = (evt => {
 			this.setState({procMode: evt.target.value, dirty: true});
-		}).bind(this);
+		});
 
 		this.setOverrideTimer = (val => {
 			this.setState({overrideTimer: val})
-		}).bind(this);
+		});
 		this.setOverrideStacks = (val => {
 			this.setState({overrideStacks: val})
-		}).bind(this);
+		});
 		this.setOverrideEnabled = (evt => {
 			this.setState({overrideEnabled: evt.target.checked})
-		}).bind(this);
+		});
 		this.deleteResourceOverride = (rscType => {
 			let overrides = this.state.initialResourceOverrides;
 			for (let i = 0; i < overrides.length; i++) {
@@ -312,7 +312,7 @@ export class Config extends React.Component {
 				}
 			}
 			this.setState({initialResourceOverrides: overrides, dirty: true});
-		}).bind(this);
+		});
 	}
 
 	// call this whenver the list of options has potentially changed
@@ -338,7 +338,7 @@ export class Config extends React.Component {
 				dirty: false,
 				selectedOverrideResource: this.#getFirstAddable(config.initialResourceOverrides)
 			});
-		}).bind(this);
+		});
 	}
 
 	#resourceOverridesAreValid() {

--- a/src/Components/SkillSequencePresets.tsx
+++ b/src/Components/SkillSequencePresets.tsx
@@ -20,7 +20,7 @@ class SaveAsPreset extends React.Component {
 		this.props = props;
 		this.onChange = ((val: string)=>{
 			this.setState({filename: val});
-		}).bind(this);
+		});
 
 		this.state = {
 			filename: "(untitled)"

--- a/src/Components/Skills.js
+++ b/src/Components/Skills.js
@@ -169,7 +169,7 @@ class SkillButton extends React.Component {
 				<div className="paragraph">{infoString}</div>
 			</div>;
 			this.setState({skillDescription: content});
-		}).bind(this);
+		});
 	}
 	render() {
 		let iconPath = skillIcons.get(this.props.skillName);
@@ -263,16 +263,16 @@ export class SkillsWindow extends React.Component {
 				retraceInfo: controller.getSkillInfo({game: controller.game, skillName: SkillName.Retrace}),
 				retraceReady: retraceReady,
 			});
-		}).bind(this);
+		});
 
 		setSkillInfoText = ((text)=>{
 			this.setState({tooltipContent: text});
-		}).bind(this);
+		});
 
 		this.onWaitTimeChange = ((e)=>{
 			if (!e || !e.target) return;
 			this.setState({waitTime: e.target.value});
-		}).bind(this);
+		});
 
 		this.onWaitTimeSubmit = ((e)=>{
 			let waitTime = parseFloat(this.state.waitTime);
@@ -301,12 +301,12 @@ export class SkillsWindow extends React.Component {
 				controller.autoSave();
 			}
 			e.preventDefault();
-		}).bind(this);
+		});
 
 		this.onWaitUntilChange = (e=>{
 			if (!e || !e.target) return;
 			this.setState({waitUntil: e.target.value});
-		}).bind(this);
+		});
 
 		this.onWaitUntilSubmit = (e=>{
 			let targetTime = parseTime(this.state.waitUntil);
@@ -321,19 +321,19 @@ export class SkillsWindow extends React.Component {
 				}
 			}
 			e.preventDefault();
-		}).bind(this);
+		});
 
 		this.onWaitSinceChange = (e=>{
 			this.setState({waitSince: e.target.value});
-		}).bind(this);
+		});
 
 		this.onRemoveTrailingIdleTime = (()=>{
 			controller.removeTrailingIdleTime();
-		}).bind(this);
+		});
 
 		this.onWaitTillNextMpOrLucidTick = (()=>{
 			controller.waitTillNextMpOrLucidTick();
-		}).bind(this);
+		});
 
 		this.state = {
 			statusList: undefined,

--- a/src/Components/StatusDisplay.js
+++ b/src/Components/StatusDisplay.js
@@ -414,7 +414,7 @@ export class StatusDisplay extends React.Component {
 				selfBuffs: newData.selfBuffs,
 				enemyBuffs: newData.enemyBuffs
 			});
-		}).bind(this);
+		});
 	}
 	componentDidMount() {
 		controller.updateStatusDisplay(controller.game);

--- a/src/Components/Timeline.tsx
+++ b/src/Components/Timeline.tsx
@@ -48,7 +48,7 @@ class TimelineMain extends React.Component {
 					visibleWidth: this.myRef.current.clientWidth
 				});
 			}
-		}).bind(this);
+		});
 	}
 	componentDidMount() {
 		this.setState({
@@ -61,7 +61,7 @@ class TimelineMain extends React.Component {
 				timelineHeight: controller.timeline.getCanvasHeight(),
 				version: this.state.version + 1
 			});
-		}).bind(this);
+		});
 
 		scrollTimelineTo = ((positionX: number)=>{
 			if (this.myRef.current != null) {
@@ -69,12 +69,12 @@ class TimelineMain extends React.Component {
 				this.myRef.current.scrollLeft = positionX - clientWidth * 0.6;
 			}
 			this.updateVisibleRange();
-		}).bind(this);
+		});
 
 		getVisibleRangeX = (()=>{return {
 			left: this.state.visibleLeft,
 			width: this.state.visibleWidth
-		}}).bind(this);
+		}});
 
 		this.updateVisibleRange();
 	}
@@ -184,13 +184,13 @@ class TimelineDisplaySettings extends React.Component {
 				controller.setTinctureBuffPercentage(percentage);
 				setCachedValue("tinctureBuffPercentage", val);
 			}
-		}).bind(this);
+		});
 		this.setUntargetableMask = ((val: boolean)=>{
 			this.setState({untargetableMask: val});
 
 			controller.setUntargetableMask(val);
 			setCachedValue("untargetableMask", val ? "1" : "0");
-		}).bind(this);
+		});
 	}
 	componentDidMount() {
 		this.setTinctureBuffPercentageStr(this.state.tinctureBuffPercentageStr);

--- a/src/Components/TimelineEditor.tsx
+++ b/src/Components/TimelineEditor.tsx
@@ -94,7 +94,7 @@ export class TimelineEditor extends React.Component {
 					});
 				}
 			}, 0);
-		}).bind(this);
+		});
 	}
 	componentWillUnmount() {
 		refreshTimelineEditor = () => {};

--- a/src/Components/TimelineMarkerPresets.tsx
+++ b/src/Components/TimelineMarkerPresets.tsx
@@ -126,7 +126,7 @@ export class TimelineMarkerPresets extends React.Component {
 					nextMarkerBuff: marker.description as BuffType
 				})
 			}
-		}).bind(this);
+		});
 
 		this.onColorChange = (evt: ChangeEvent<{value: string}>)=>{
 			if (evt.target) {
@@ -173,7 +173,7 @@ export class TimelineMarkerPresets extends React.Component {
 
 		updateMarkers_TimelineMarkerPresets = ((trackBins: Map<number, MarkerElem[]>) => {
 			this.setState({trackBins: trackBins});
-		}).bind(this);
+		});
 	}
 
 	componentWillUnmount() {

--- a/src/Game/Potency.ts
+++ b/src/Game/Potency.ts
@@ -1,5 +1,4 @@
 import {controller} from "../Controller/Controller";
-import { Record } from "../Controller/Record";
 import {Aspect, BuffType, Debug, ResourceType, SkillName} from "./Common";
 import { GameConfig } from "./GameConfig";
 import {ResourceState} from "./Resources";

--- a/src/Game/Resources.ts
+++ b/src/Game/Resources.ts
@@ -98,9 +98,6 @@ export class Resource {
 export class DoTBuff extends Resource {
 	node?: ActionNode = undefined;
 	tickCount: number = 0;
-	constructor(type: ResourceType, maxValue: number, initialValue: number) {
-		super(type, maxValue, initialValue);
-	}
 }
 
 export class CoolDown extends Resource {


### PR DESCRIPTION
This fixes a bunch of warnings that were raised during `npm start`/`npm build` by running `./node_modules/.bin/eslint --fix --ext .js,.jsx,.ts,.tsx` src/`.

Notably, it removes a lot of calls to bind (which [don't work on arrow functions](https://eslint.org/docs/latest/rules/no-extra-bind)) and a couple trivial constructors ([one is generated by default](https://eslint.org/docs/latest/rules/no-useless-constructor)).

I removed a few unused imports, but there's still some variables the linter is reporting as unused that I elected not to touch for now. @miyehn when you get the time, can you check the remaining warnings and either suppress them or remove variables as needed?