### PR TITLE
Level Syncing - Add Explicit Level Requirements to Skill Usage

### DIFF
--- a/src/Game/Common.ts
+++ b/src/Game/Common.ts
@@ -74,6 +74,7 @@ export const enum SkillReadyStatus {
 	Blocked = "blocked by CD, animation lock or caster tax",
 	NotEnoughMP = "not enough MP",
 	RequirementsNotMet = "requirements not met",
+	SkillNotUnlocked = "skill not unlocked at provided level",
 	BuffNoLongerAvailable = "buff no longer available"
 }
 

--- a/src/Game/GameState.ts
+++ b/src/Game/GameState.ts
@@ -736,8 +736,10 @@ export class GameState {
 			|| (skillName===SkillName.Paradox && this.getIceStacks() > 0)
 			|| (skillName===SkillName.Fire3 && this.resources.get(ResourceType.Firestarter).available((1)));
 		let reqsMet = skill.available();
+		let skillUnlocked = this.config.level >= skill.info.level;
 		let status = SkillReadyStatus.Ready;
 		if (!notBlocked) status = SkillReadyStatus.Blocked;
+		else if (!skillUnlocked) status = SkillReadyStatus.SkillNotUnlocked;
 		else if (!reqsMet) status = SkillReadyStatus.RequirementsNotMet;
 		else if (!enoughMana) status = SkillReadyStatus.NotEnoughMP;
 

--- a/src/Game/Skills.ts
+++ b/src/Game/Skills.ts
@@ -17,6 +17,7 @@ export interface SkillApplicationCallbackInfo {
 
 export class SkillInfo {
 	readonly name: SkillName;
+	readonly level: number;
 	readonly cdName: ResourceType;
 	readonly aspect: Aspect;
 	readonly isSpell: boolean;
@@ -27,6 +28,7 @@ export class SkillInfo {
 
 	constructor(
 		skillName: SkillName,
+		level: number,
 		cdName: ResourceType,
 		aspect: Aspect,
 		isSpell: boolean,
@@ -36,6 +38,7 @@ export class SkillInfo {
 		skillApplicationDelay?: number)
 	{
 		this.name = skillName;
+		this.level = level;
 		this.cdName = cdName;
 		this.aspect = aspect;
 		this.isSpell = isSpell;
@@ -52,84 +55,84 @@ export class SkillInfo {
 // https://www.fflogs.com/reports/cNpjtRXHhZ8Az2V3#fight=last&type=damage-done&view=events&ability=36987
 // https://www.fflogs.com/reports/7NMQkxLzcbptw3Xd#fight=15&type=damage-done&source=116&view=events&ability=36986
 const skillInfos = [
-	new SkillInfo(SkillName.Blizzard, ResourceType.cd_GCD, Aspect.Ice, true,
+	new SkillInfo(SkillName.Blizzard, 1, ResourceType.cd_GCD, Aspect.Ice, true,
 		2.5, 400, 180, 0.846),
-	new SkillInfo(SkillName.Fire, ResourceType.cd_GCD, Aspect.Fire, true,
+	new SkillInfo(SkillName.Fire, 2, ResourceType.cd_GCD, Aspect.Fire, true,
 		2.5, 800, 180, 1.871),
-	new SkillInfo(SkillName.Blizzard2, ResourceType.cd_GCD, Aspect.Ice, true,
+	new SkillInfo(SkillName.Blizzard2, 12, ResourceType.cd_GCD, Aspect.Ice, true,
 		3, 800, 80, 1.158), // Unknown damage application, copied from HB2
-	new SkillInfo(SkillName.Fire2, ResourceType.cd_GCD, Aspect.Fire, true,
+	new SkillInfo(SkillName.Fire2, 18, ResourceType.cd_GCD, Aspect.Fire, true,
 		3, 1500, 80, 1.154), // Unknown damage application, copied from HF2
-	new SkillInfo(SkillName.Transpose, ResourceType.cd_Transpose, Aspect.Other, false,
+	new SkillInfo(SkillName.Transpose, 4, ResourceType.cd_Transpose, Aspect.Other, false,
 		0, 0, 0), // instant
-	new SkillInfo(SkillName.Thunder3, ResourceType.cd_GCD, Aspect.Lightning, true,
+	new SkillInfo(SkillName.Thunder3, 45, ResourceType.cd_GCD, Aspect.Lightning, true,
 		0, 0, 120, 0.757), // Unknown damage application, copied from HT
-	new SkillInfo(SkillName.Manaward, ResourceType.cd_Manaward, Aspect.Other, false,
+	new SkillInfo(SkillName.Manaward, 30, ResourceType.cd_Manaward, Aspect.Other, false,
 		0, 0, 0, 1.114),// delayed
 	// Manafont: application delay 0.88s -> 0.2s since Dawntrail
 	// infact most effects seem instant but MP gain is delayed.
 	// see screen recording: https://drive.google.com/file/d/1zGhU9egAKJ3PJiPVjuRBBMkKdxxHLS9b/view?usp=drive_link
-	new SkillInfo(SkillName.Manafont, ResourceType.cd_Manafont, Aspect.Other, false,
+	new SkillInfo(SkillName.Manafont, 30, ResourceType.cd_Manafont, Aspect.Other, false,
 		0, 0, 0, 0.2),
-	new SkillInfo(SkillName.Fire3, ResourceType.cd_GCD, Aspect.Fire, true,
+	new SkillInfo(SkillName.Fire3, 35, ResourceType.cd_GCD, Aspect.Fire, true,
 		3.5, 2000, 280, 1.292),
-	new SkillInfo(SkillName.Blizzard3, ResourceType.cd_GCD, Aspect.Ice, true,
+	new SkillInfo(SkillName.Blizzard3, 35, ResourceType.cd_GCD, Aspect.Ice, true,
 		3.5, 800, 280, 0.89),
-	new SkillInfo(SkillName.Freeze, ResourceType.cd_GCD, Aspect.Ice, true,
+	new SkillInfo(SkillName.Freeze, 40, ResourceType.cd_GCD, Aspect.Ice, true,
 		2.8, 1000, 120, 0.664),
-	new SkillInfo(SkillName.Flare, ResourceType.cd_GCD, Aspect.Fire, true,
+	new SkillInfo(SkillName.Flare, 50, ResourceType.cd_GCD, Aspect.Fire, true,
 		4, 0, 240, 1.157), // mana is handled separately
 
-	new SkillInfo(SkillName.LeyLines, ResourceType.cd_LeyLines, Aspect.Other, false,
+	new SkillInfo(SkillName.LeyLines, 52, ResourceType.cd_LeyLines, Aspect.Other, false,
 		0, 0, 0, 0.49),// delayed
-	new SkillInfo(SkillName.Blizzard4, ResourceType.cd_GCD, Aspect.Ice, true,
+	new SkillInfo(SkillName.Blizzard4, 58, ResourceType.cd_GCD, Aspect.Ice, true,
 		2.5, 800, 320, 1.156),
-	new SkillInfo(SkillName.Fire4, ResourceType.cd_GCD, Aspect.Fire, true,
+	new SkillInfo(SkillName.Fire4, 60, ResourceType.cd_GCD, Aspect.Fire, true,
 		2.8, 800, 320, 1.159),
-	new SkillInfo(SkillName.BetweenTheLines, ResourceType.cd_BetweenTheLines, Aspect.Other, false,
+	new SkillInfo(SkillName.BetweenTheLines, 62, ResourceType.cd_BetweenTheLines, Aspect.Other, false,
 		0, 0, 0), // ?
-	new SkillInfo(SkillName.AetherialManipulation, ResourceType.cd_AetherialManipulation, Aspect.Other, false,
+	new SkillInfo(SkillName.AetherialManipulation, 50, ResourceType.cd_AetherialManipulation, Aspect.Other, false,
 		0, 0, 0), // ?
-	new SkillInfo(SkillName.Triplecast, ResourceType.cd_Triplecast, Aspect.Other, false,
+	new SkillInfo(SkillName.Triplecast, 66, ResourceType.cd_Triplecast, Aspect.Other, false,
 		0, 0, 0), // instant
 
-	new SkillInfo(SkillName.Foul, ResourceType.cd_GCD, Aspect.Other, true,
+	new SkillInfo(SkillName.Foul, 70, ResourceType.cd_GCD, Aspect.Other, true,
 		2.5, 0, 600, 1.158),
-	new SkillInfo(SkillName.Despair, ResourceType.cd_GCD, Aspect.Fire, true,
+	new SkillInfo(SkillName.Despair, 72, ResourceType.cd_GCD, Aspect.Fire, true,
 		3, 0, 350, 0.556),
 	// Umbral Soul: immediate snapshot & UH gain; delayed MP gain
 	// see screen recording: https://drive.google.com/file/d/1nsO69O7lgc8V_R_To4X0TGalPsCus1cg/view?usp=drive_link
-	new SkillInfo(SkillName.UmbralSoul, ResourceType.cd_GCD, Aspect.Ice, true,
+	new SkillInfo(SkillName.UmbralSoul, 35, ResourceType.cd_GCD, Aspect.Ice, true,
 		0, 0, 0, 0.633),
-	new SkillInfo(SkillName.Xenoglossy, ResourceType.cd_GCD, Aspect.Other, true,
+	new SkillInfo(SkillName.Xenoglossy, 80, ResourceType.cd_GCD, Aspect.Other, true,
 		0, 0, 880, 0.63),
 
-	new SkillInfo(SkillName.HighFire2, ResourceType.cd_GCD, Aspect.Fire, true,
+	new SkillInfo(SkillName.HighFire2, 82, ResourceType.cd_GCD, Aspect.Fire, true,
 		3, 1500, 100, 1.154),
-	new SkillInfo(SkillName.HighBlizzard2, ResourceType.cd_GCD, Aspect.Ice, true,
+	new SkillInfo(SkillName.HighBlizzard2, 82, ResourceType.cd_GCD, Aspect.Ice, true,
 		3, 800, 100, 1.158),
-	new SkillInfo(SkillName.Amplifier, ResourceType.cd_Amplifier, Aspect.Other, false,
+	new SkillInfo(SkillName.Amplifier, 86, ResourceType.cd_Amplifier, Aspect.Other, false,
 		0, 0, 0), // ? (assumed to be instant)
-	new SkillInfo(SkillName.Paradox, ResourceType.cd_GCD, Aspect.Other, true,
+	new SkillInfo(SkillName.Paradox, 90, ResourceType.cd_GCD, Aspect.Other, true,
 		0, 1600, 520, 0.624),
-	new SkillInfo(SkillName.HighThunder, ResourceType.cd_GCD, Aspect.Lightning, true,
+	new SkillInfo(SkillName.HighThunder, 92, ResourceType.cd_GCD, Aspect.Lightning, true,
 		0, 0, 150, 0.757),
-	new SkillInfo(SkillName.FlareStar, ResourceType.cd_GCD, Aspect.Fire, true,
+	new SkillInfo(SkillName.FlareStar, 100, ResourceType.cd_GCD, Aspect.Fire, true,
 		3, 0, 400, 0.622), /* Get actual delay after release */
-	new SkillInfo(SkillName.Retrace, ResourceType.cd_Retrace, Aspect.Other, false,
+	new SkillInfo(SkillName.Retrace, 96, ResourceType.cd_Retrace, Aspect.Other, false,
 		0, 0, 0), // ? (assumed to be instant)
 
-	new SkillInfo(SkillName.Addle, ResourceType.cd_Addle, Aspect.Other, false,
+	new SkillInfo(SkillName.Addle, 8, ResourceType.cd_Addle, Aspect.Other, false,
 		0, 0, 0, 0.621),// delayed
-	new SkillInfo(SkillName.Swiftcast, ResourceType.cd_Swiftcast, Aspect.Other, false,
+	new SkillInfo(SkillName.Swiftcast, 18, ResourceType.cd_Swiftcast, Aspect.Other, false,
 		0, 0, 0), // instant
-	new SkillInfo(SkillName.LucidDreaming, ResourceType.cd_LucidDreaming, Aspect.Other, false,
+	new SkillInfo(SkillName.LucidDreaming, 14, ResourceType.cd_LucidDreaming, Aspect.Other, false,
 		0, 0, 0, 0.623), // delayed
-	new SkillInfo(SkillName.Surecast, ResourceType.cd_Surecast, Aspect.Other, false,
+	new SkillInfo(SkillName.Surecast, 44, ResourceType.cd_Surecast, Aspect.Other, false,
 		0, 0, 0), // surprisingly instant because arms length is not
-	new SkillInfo(SkillName.Tincture, ResourceType.cd_Tincture, Aspect.Other, false,
+	new SkillInfo(SkillName.Tincture, 1, ResourceType.cd_Tincture, Aspect.Other, false,
 		0, 0, 0, 0.64),// delayed // somewhere in the midrange of what's seen in logs
-	new SkillInfo(SkillName.Sprint, ResourceType.cd_Sprint, Aspect.Other, false,
+	new SkillInfo(SkillName.Sprint, 1, ResourceType.cd_Sprint, Aspect.Other, false,
 		0, 0, 0, 0.133)// delayed
 ];
 


### PR DESCRIPTION
* Prevents adding skills to the timeline that haven't been unlocked according to the config's level, even when using presets.
* Throws as "insufficient resources and/or stats mismatch" error.
* Could perhaps be friendlier and convert equivalent buttons (F2->HF2, T3->HT).