### PR TITLE
Add some tests

### DIFF
--- a/src/BlmRotations.test.ts
+++ b/src/BlmRotations.test.ts
@@ -3,7 +3,8 @@
 import {controller} from "./Controller/Controller";
 import {TickMode} from "./Controller/Common";
 import {DEFAULT_CONFIG, GameConfig} from "./Game/GameConfig";
-import {PotencyModifier, PotencyModifierType} from "../Game/Potency";
+import {PotencyModifier, PotencyModifierType} from "./Game/Potency";
+import {SkillName} from "./Game/Common";
 import {DamageStatisticsData} from "./Components/DamageStatistics";
 
 const DamageStatistics = require("./Components/DamageStatistics");
@@ -45,18 +46,20 @@ beforeEach(() => {
         tickMode: TickMode.Manual,
     });
     // monkeypatch the updateDamageStats function to avoid needing to initialize the frontend
-    DamageStatistics.exports.updateDamageStats = (newData) => {
+    DamageStatistics.exports.updateDamageStats = (newData: DamageStatisticsData) => {
         damageData = newData;
     };
 });
 
 // Run a test with the provided partial GameConfig and test function
 // Leave `params`` as an empty object to use the default config
-const testWithConfig = (params: Partial<GameConfig>, testFn: () => undefined) => {
-    const newConfig = {...DEFAULT_CONFIG};
-    Object.defineProperties(newConfig, params);
-    controller.setConfigAndRestart(newConfig);
-    testFn();
+const testWithConfig = (params: Partial<GameConfig>, testFn: () => void) => {
+    return () => {
+        const newConfig = {...DEFAULT_CONFIG};
+        Object.defineProperties(newConfig, params);
+        controller.setConfigAndRestart(newConfig);
+        testFn();
+    };
 };
 
 const applySkill = (skillName: SkillName) => {

--- a/src/BlmRotations.test.ts
+++ b/src/BlmRotations.test.ts
@@ -252,7 +252,7 @@ it("removes paradox on enochian drop", testWithConfig({ spellSpeed : 420 }, () =
 }));
 
 
-it("has different F1 potencies at different AF/UI states", testWithConfig({}, () => {
+it("has different F1 modifiers at different AF/UI states", testWithConfig({}, () => {
     [
         SkillName.Fire, // no eno
         SkillName.Fire, // AF1

--- a/src/BlmRotations.test.ts
+++ b/src/BlmRotations.test.ts
@@ -1,0 +1,144 @@
+// Tests for potencies and basic job gauge validation for BLM.
+
+import {controller} from "./Controller/Controller";
+import {TickMode} from "./Controller/Common";
+import {DEFAULT_CONFIG, GameConfig} from "./Game/GameConfig";
+import {PotencyModifier, PotencyModifierType} from "../Game/Potency";
+import {DamageStatisticsData} from "./Components/DamageStatistics";
+
+const DamageStatistics = require("./Components/DamageStatistics");
+
+let damageData: DamageStatisticsData = {
+    time: 0,
+    tinctureBuffPercentage: 0,
+    countdown: 0,
+    totalPotency: {applied: 0, pending: 0},
+    lastDamageApplicationTime: 0,
+    gcdSkills: {applied: 0, pending: 0},
+    mainTable: [],
+    mainTableSummary: {
+        totalPotencyWithoutPot: 0, 
+        totalPotPotency: 0,
+        totalPartyBuffPotency: 0,
+    },
+    thunderTable: [],
+    thunderTableSummary: {
+        cumulativeGap: 0,
+        cumulativeOverride: 0,
+        timeSinceLastDoTDropped: 0,
+        totalTicks: 0,
+        maxTicks: 0,
+        dotCoverageTimeFraction: 0,
+        theoreticalMaxTicks: 0,
+        totalPotencyWithoutPot: 0,
+        totalPotPotency: 0,
+        totalPartyBuffPotency: 0,
+    },
+    historical: false,
+};
+
+beforeEach(() => {
+    // for simplicity, always use "manual" advance mode to avoid any time shenanigans
+    // we eventually should test real-time mode as well
+    controller.setTimeControlSettings({
+        timeScale: 2,
+        tickMode: TickMode.Manual,
+    });
+    // monkeypatch the updateDamageStats function to avoid needing to initialize the frontend
+    DamageStatistics.exports.updateDamageStats = (newData) => {
+        damageData = newData;
+    };
+});
+
+// Run a test with the provided partial GameConfig and test function
+// Leave `params`` as an empty object to use the default config
+const testWithConfig = (params: Partial<GameConfig>, testFn: () => undefined) => {
+    const newConfig = {...DEFAULT_CONFIG};
+    Object.defineProperties(newConfig, params);
+    controller.setConfigAndRestart(newConfig);
+    testFn();
+};
+
+const applySkill = (skillName: SkillName) => {
+    // Perform the specified skill as soon as possible
+    // TEST-ONLY HACK: set lastAttemptedSkill to the skill we're about to use
+    // to ensure that trailing wait times are always omitted
+    controller.lastAttemptedSkill = skillName;
+    controller.requestUseSkill({skillName: skillName});
+};
+
+it("accepts the standard rotation", testWithConfig({}, () => {
+    [
+        SkillName.Blizzard3, // precast, no enochian
+        SkillName.Blizzard4,
+        SkillName.Fire3,
+        SkillName.Fire4,
+        SkillName.Fire4,
+        SkillName.Fire4,
+        SkillName.Fire4,
+        SkillName.Paradox,
+        SkillName.Fire4,
+        SkillName.Fire4,
+        SkillName.Despair,
+        SkillName.FlareStar,
+    ].forEach(applySkill);
+    // wait 4 seconds for cast finish + damage application
+    controller.step(4);
+    const expectedDamageEntries = new Set([
+        {
+            skillName: SkillName.Blizzard3,
+            displayedModifiers: [], // unaspected
+            hitCount: 1,
+        },
+        {
+            skillName: SkillName.Blizzard4,
+            displayedModifiers: [PotencyModifierType.UI3],
+            hitCount: 1,
+        },
+        {
+            skillName: SkillName.Fire3,
+            displayedModifiers: [PotencyModifierType.UI3],
+            hitCount: 1,
+        },
+        {
+            skillName: SkillName.Fire4,
+            displayedModifiers: [PotencyModifierType.AF3],
+            hitCount: 6,
+        },
+        {
+            skillName: SkillName.Paradox,
+            displayedModifiers: [],
+            hitCount: 1,
+        },
+        {
+            skillName: SkillName.Despair,
+            displayedModifiers: [PotencyModifierType.AF3],
+            hitCount: 1,
+        },
+        {
+            skillName: SkillName.FlareStar,
+            displayedModifiers: [PotencyModifierType.AF3],
+            hitCount: 1,
+        },
+    ]);
+    const actualDamageEntries = new Set();
+    for (const entry of damageData.mainTable) {
+        actualDamageEntries.add({
+            skillName: entry.skillName,
+            displayedModifiers: entry.displayedModifiers,
+            hitCount: entry.hitCount,
+        });
+    }
+    expect(actualDamageEntries.size).toEqual(expectedDamageEntries.size);
+    expect(actualDamageEntries.difference(expectedDamageEntries).size).toEqual(0);
+}));
+
+
+// things to test:
+// enochian-dropping lines
+// lines near sps breakpoints
+// lines that don't have enough mp
+// potency modifiers (AF3, UI3, etc.)
+// umbral soul stops timer
+// polyglot generation
+// level synced potency values + replaced skills like HT/T3

--- a/src/Components/DamageStatistics.tsx
+++ b/src/Components/DamageStatistics.tsx
@@ -94,6 +94,11 @@ export type DamageStatisticsData = {
 export let updateDamageStats = (data: DamageStatisticsData) => {};
 export let updateSelectedStats = (data: SelectedStatisticsData) => {};
 
+// hook for tests to access damage stats
+export const mockDamageStatUpdateFn = (updateFn: (update: DamageStatisticsData) => void) => {
+	updateDamageStats = updateFn;
+};
+
 function buffName(buff: PotencyModifierType) {
 	let text = "";
 	if (buff === PotencyModifierType.AF3) {


### PR DESCRIPTION
This PR adds tests. These test cases use the global controller object (initialized through some magic), hooks into the damage statistics table, and checks the validity of a few basic lines. I did not add any tests for exact potency numbers since I didn't want them to potentially change every patch, but I did check for the presence of modifiers in the damage table.

The tested cases are as follows:
- 1 iteration of the standard rotation: [unaspected] B3 B4 F3 4xF4 para 2xF4 despair FS
- enochian drop during despair cast raises error: B3 F3 4xF4 despair
- enochian drop removes paradox marker: F3 swift B3 [wait 15s]
- F1 has different modifiers depending on gauge state: F1 F1 F1 F1 B3 para F1